### PR TITLE
[shadcn/ui] Dialog 컴포넌트 분석

### DIFF
--- a/shadcn-ui/dialog/Dialog.tsx
+++ b/shadcn-ui/dialog/Dialog.tsx
@@ -1,0 +1,162 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+// Dialog도 마찬가지로 shadcn은 "행동"을 직접 구현하지 않음
+// -> radix-ui 컴포넌트 위에 UI 레이어를 쌓는 방식
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />  // Button에서 봤던 data-slot 패턴이 동일하게 사용
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+
+      // open / closed 상태는 Radix가 "data-state"로 내려줌
+      // shadcn은 그걸 JS에서 상태 분기처리하지 않고 CSS에 위임
+      className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          // asChild를 사용해 data-slot="dialog-close"가 자식 태그인 Button으로 넘어감
+          // Radix-UI의 닫기 버튼 기능은 그대로 가져가되 사용하는 UI는 Shadcn의 Button을 사용하기 위함
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm">
+              <XIcon
+              />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("gap-2 flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-base leading-none font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/shadcn-ui/dialog/Radix-UI_Dialog.tsx
+++ b/shadcn-ui/dialog/Radix-UI_Dialog.tsx
@@ -1,0 +1,635 @@
+import * as React from 'react';
+
+// 여러 이벤트 핸들러를 하나로 합치는 유틸
+import { composeEventHandlers } from '@radix-ui/primitive';
+
+// forwardRef와 내부에서 관리하는 ref를 하나로 묶기 위한 훅
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
+
+// Dialog 전용 Context와 Scopte 생성
+import { createContext, createContextScope } from '@radix-ui/react-context';
+
+// 접근성용 ID 생성 (title, description 연결용)
+import { useId } from '@radix-ui/react-id';
+
+// controlled / uncontrolled 상태를 관리하는 훅
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
+
+// ESC, 바깥 클릭 등으로 닫히는 레이어
+import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
+
+// 포커스 스코프
+import { FocusScope } from '@radix-ui/react-focus-scope';
+
+// 실제 DOM 위치를 body 쪽으로 보내기 위한 Portal
+import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
+
+// mount / unmount 제어
+import { Presence } from '@radix-ui/react-presence';
+
+// 스타일이 없는 기본 HTML wrapper (radix는 스타일이 아닌 behavior만 책임짐)
+import { Primitive } from '@radix-ui/react-primitive';
+
+// Portal 환경에서 focus 이동이 깨지지 않도록 보조 노드 추가
+import { useFocusGuards } from '@radix-ui/react-focus-guards';
+
+// Dialog가 열려 있을 때 background scroll 막기
+import { RemoveScroll } from 'react-remove-scroll';
+
+// Dialog의 DOM을 aria-hidden 처리
+import { hideOthers } from 'aria-hidden';
+
+// 특정 컴포넌트를 감싸는 slot 생성
+import { createSlot } from '@radix-ui/react-slot';
+
+import type { Scope } from '@radix-ui/react-context';
+
+/* -------------------------------------------------------------------------------------------------
+ * Dialog
+ * -----------------------------------------------------------------------------------------------*/
+
+const DIALOG_NAME = 'Dialog';
+
+// 내부에서만 쓰는 scope prop을 사용자 props와 분리
+type ScopedProps<P> = P & { __scopeDialog?: Scope };
+
+// Dialog 전용 context + scope 생성
+const [createDialogContext, createDialogScope] = createContextScope(DIALOG_NAME);
+
+type DialogContextValue = {
+  // trigger / content ref를 context로 공유
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+  contentRef: React.RefObject<DialogContentElement | null>;
+
+  // 연결을 위한 id들
+  contentId: string;
+  titleId: string;
+  descriptionId: string;
+
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  onOpenToggle(): void;
+  modal: boolean;
+};
+
+const [DialogProvider, useDialogContext] = createDialogContext<DialogContextValue>(DIALOG_NAME);
+
+interface DialogProps {
+  children?: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?(open: boolean): void;
+  modal?: boolean;
+}
+
+const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
+  const {
+    __scopeDialog,
+    children,
+    open: openProp,
+    defaultOpen,
+    onOpenChange,
+    modal = true,
+  } = props;
+
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const contentRef = React.useRef<DialogContentElement>(null);
+
+  // Dialog의 핵심 상태
+  // -> 실제 open 상태는 여기서만 관리되고 나머지 컴포넌트는 context를 통해 소비만 함
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen ?? false,
+    onChange: onOpenChange,
+    caller: DIALOG_NAME,
+  });
+
+  return (
+    <DialogProvider
+      scope={__scopeDialog}
+      triggerRef={triggerRef}
+      contentRef={contentRef}
+      contentId={useId()}
+      titleId={useId()}
+      descriptionId={useId()}
+      open={open}
+      onOpenChange={setOpen}
+      onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
+      modal={modal}
+    >
+      {children}
+    </DialogProvider>
+  );
+};
+
+Dialog.displayName = DIALOG_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * DialogTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const TRIGGER_NAME = 'DialogTrigger';
+
+type DialogTriggerElement = React.ComponentRef<typeof Primitive.button>;
+type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface DialogTriggerProps extends PrimitiveButtonProps {}
+
+const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>(
+  (props: ScopedProps<DialogTriggerProps>, forwardedRef) => {
+    const { __scopeDialog, ...triggerProps } = props;
+    const context = useDialogContext(TRIGGER_NAME, __scopeDialog);
+
+    // 외부 ref + Dialog 내부 ref 동기화
+    const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
+
+    return (
+      <Primitive.button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={context.open}
+        aria-controls={context.contentId}
+        data-state={getState(context.open)}
+        {...triggerProps}
+        ref={composedTriggerRef}
+
+        // 사용자 onClick을 유지하면서 Dialog 열기/닫기 동작 추가
+        onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
+      />
+    );
+  },
+);
+
+DialogTrigger.displayName = TRIGGER_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * DialogPortal
+ * -----------------------------------------------------------------------------------------------*/
+
+const PORTAL_NAME = 'DialogPortal';
+
+type PortalContextValue = { forceMount?: true };
+const [PortalProvider, usePortalContext] = createDialogContext<PortalContextValue>(PORTAL_NAME, {
+  forceMount: undefined,
+});
+
+type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
+interface DialogPortalProps {
+  children?: React.ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps['container'];
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
+
+const DialogPortal: React.FC<DialogPortalProps> = (props: ScopedProps<DialogPortalProps>) => {
+  const { __scopeDialog, forceMount, children, container } = props;
+  const context = useDialogContext(PORTAL_NAME, __scopeDialog);
+  return (
+    <PortalProvider scope={__scopeDialog} forceMount={forceMount}>
+      {React.Children.map(children, (child) => (
+        <Presence present={forceMount || context.open}>
+          <PortalPrimitive asChild container={container}>
+            {child}
+          </PortalPrimitive>
+        </Presence>
+      ))}
+    </PortalProvider>
+  );
+};
+
+DialogPortal.displayName = PORTAL_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * DialogOverlay
+ * -----------------------------------------------------------------------------------------------*/
+
+const OVERLAY_NAME = 'DialogOverlay';
+
+type DialogOverlayElement = DialogOverlayImplElement;
+interface DialogOverlayProps extends DialogOverlayImplProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
+
+const DialogOverlay = React.forwardRef<DialogOverlayElement, DialogOverlayProps>(
+  (props: ScopedProps<DialogOverlayProps>, forwardedRef) => {
+    const portalContext = usePortalContext(OVERLAY_NAME, props.__scopeDialog);
+    const { forceMount = portalContext.forceMount, ...overlayProps } = props;
+    const context = useDialogContext(OVERLAY_NAME, props.__scopeDialog);
+    return context.modal ? (
+      <Presence present={forceMount || context.open}>
+        <DialogOverlayImpl {...overlayProps} ref={forwardedRef} />
+      </Presence>
+    ) : null;
+  },
+);
+
+DialogOverlay.displayName = OVERLAY_NAME;
+
+type DialogOverlayImplElement = React.ComponentRef<typeof Primitive.div>;
+type PrimitiveDivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface DialogOverlayImplProps extends PrimitiveDivProps {}
+
+const Slot = createSlot('DialogOverlay.RemoveScroll');
+
+const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverlayImplProps>(
+  (props: ScopedProps<DialogOverlayImplProps>, forwardedRef) => {
+    const { __scopeDialog, ...overlayProps } = props;
+    const context = useDialogContext(OVERLAY_NAME, __scopeDialog);
+    return (
+      // Make sure `Content` is scrollable even when it doesn't live inside `RemoveScroll`
+      // ie. when `Overlay` and `Content` are siblings
+      <RemoveScroll as={Slot} allowPinchZoom shards={[context.contentRef]}>
+        <Primitive.div
+          data-state={getState(context.open)}
+          {...overlayProps}
+          ref={forwardedRef}
+          // We re-enable pointer-events prevented by `Dialog.Content` to allow scrolling the overlay.
+          style={{ pointerEvents: 'auto', ...overlayProps.style }}
+        />
+      </RemoveScroll>
+    );
+  },
+);
+
+/* -------------------------------------------------------------------------------------------------
+ * DialogContent
+ * -----------------------------------------------------------------------------------------------*/
+
+const CONTENT_NAME = 'DialogContent';
+
+type DialogContentElement = DialogContentTypeElement;
+interface DialogContentProps extends DialogContentTypeProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
+
+const DialogContent = React.forwardRef<DialogContentElement, DialogContentProps>(
+  (props: ScopedProps<DialogContentProps>, forwardedRef) => {
+    const portalContext = usePortalContext(CONTENT_NAME, props.__scopeDialog);
+    const { forceMount = portalContext.forceMount, ...contentProps } = props;
+    const context = useDialogContext(CONTENT_NAME, props.__scopeDialog);
+    return (
+      <Presence present={forceMount || context.open}>
+        {context.modal ? (
+          <DialogContentModal {...contentProps} ref={forwardedRef} />
+        ) : (
+          <DialogContentNonModal {...contentProps} ref={forwardedRef} />
+        )}
+      </Presence>
+    );
+  },
+);
+
+DialogContent.displayName = CONTENT_NAME;
+
+/* -----------------------------------------------------------------------------------------------*/
+
+type DialogContentTypeElement = DialogContentImplElement;
+interface DialogContentTypeProps
+  extends Omit<DialogContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {}
+
+const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogContentTypeProps>(
+  (props: ScopedProps<DialogContentTypeProps>, forwardedRef) => {
+    const context = useDialogContext(CONTENT_NAME, props.__scopeDialog);
+    const contentRef = React.useRef<HTMLDivElement>(null);
+    const composedRefs = useComposedRefs(forwardedRef, context.contentRef, contentRef);
+
+    // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+    React.useEffect(() => {
+      const content = contentRef.current;
+      if (content) return hideOthers(content);
+    }, []);
+
+    return (
+      <DialogContentImpl
+        {...props}
+        ref={composedRefs}
+        // we make sure focus isn't trapped once `DialogContent` has been closed
+        // (closed !== unmounted when animating out)
+        trapFocus={context.open}
+        disableOutsidePointerEvents
+        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+          event.preventDefault();
+          context.triggerRef.current?.focus();
+        })}
+        onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+          const originalEvent = event.detail.originalEvent;
+          const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
+          const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
+
+          // If the event is a right-click, we shouldn't close because
+          // it is effectively as if we right-clicked the `Overlay`.
+          if (isRightClick) event.preventDefault();
+        })}
+        // When focus is trapped, a `focusout` event may still happen.
+        // We make sure we don't trigger our `onDismiss` in such case.
+        onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+          event.preventDefault(),
+        )}
+      />
+    );
+  },
+);
+
+/* -----------------------------------------------------------------------------------------------*/
+
+const DialogContentNonModal = React.forwardRef<DialogContentTypeElement, DialogContentTypeProps>(
+  (props: ScopedProps<DialogContentTypeProps>, forwardedRef) => {
+    const context = useDialogContext(CONTENT_NAME, props.__scopeDialog);
+    const hasInteractedOutsideRef = React.useRef(false);
+    const hasPointerDownOutsideRef = React.useRef(false);
+
+    return (
+      <DialogContentImpl
+        {...props}
+        ref={forwardedRef}
+        trapFocus={false}
+        disableOutsidePointerEvents={false}
+        onCloseAutoFocus={(event) => {
+          props.onCloseAutoFocus?.(event);
+
+          if (!event.defaultPrevented) {
+            if (!hasInteractedOutsideRef.current) context.triggerRef.current?.focus();
+            // Always prevent auto focus because we either focus manually or want user agent focus
+            event.preventDefault();
+          }
+
+          hasInteractedOutsideRef.current = false;
+          hasPointerDownOutsideRef.current = false;
+        }}
+        onInteractOutside={(event) => {
+          props.onInteractOutside?.(event);
+
+          if (!event.defaultPrevented) {
+            hasInteractedOutsideRef.current = true;
+            if (event.detail.originalEvent.type === 'pointerdown') {
+              hasPointerDownOutsideRef.current = true;
+            }
+          }
+
+          // Prevent dismissing when clicking the trigger.
+          // As the trigger is already setup to close, without doing so would
+          // cause it to close and immediately open.
+          const target = event.target as HTMLElement;
+          const targetIsTrigger = context.triggerRef.current?.contains(target);
+          if (targetIsTrigger) event.preventDefault();
+
+          // On Safari if the trigger is inside a container with tabIndex={0}, when clicked
+          // we will get the pointer down outside event on the trigger, but then a subsequent
+          // focus outside event on the container, we ignore any focus outside event when we've
+          // already had a pointer down outside event.
+          if (event.detail.originalEvent.type === 'focusin' && hasPointerDownOutsideRef.current) {
+            event.preventDefault();
+          }
+        }}
+      />
+    );
+  },
+);
+
+/* -----------------------------------------------------------------------------------------------*/
+
+type DialogContentImplElement = React.ComponentRef<typeof DismissableLayer>;
+type DismissableLayerProps = React.ComponentPropsWithoutRef<typeof DismissableLayer>;
+type FocusScopeProps = React.ComponentPropsWithoutRef<typeof FocusScope>;
+interface DialogContentImplProps extends Omit<DismissableLayerProps, 'onDismiss'> {
+  /**
+   * When `true`, focus cannot escape the `Content` via keyboard,
+   * pointer, or a programmatic focus.
+   * @defaultValue false
+   */
+  trapFocus?: FocusScopeProps['trapped'];
+
+  /**
+   * Event handler called when auto-focusing on open.
+   * Can be prevented.
+   */
+  onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
+
+  /**
+   * Event handler called when auto-focusing on close.
+   * Can be prevented.
+   */
+  onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
+}
+
+const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogContentImplProps>(
+  (props: ScopedProps<DialogContentImplProps>, forwardedRef) => {
+    const { __scopeDialog, trapFocus, onOpenAutoFocus, onCloseAutoFocus, ...contentProps } = props;
+    const context = useDialogContext(CONTENT_NAME, __scopeDialog);
+    const contentRef = React.useRef<HTMLDivElement>(null);
+    const composedRefs = useComposedRefs(forwardedRef, contentRef);
+
+    // Make sure the whole tree has focus guards as our `Dialog` will be
+    // the last element in the DOM (because of the `Portal`)
+    useFocusGuards();
+
+    return (
+      <>
+        <FocusScope
+          asChild
+          loop
+          trapped={trapFocus}
+          onMountAutoFocus={onOpenAutoFocus}
+          onUnmountAutoFocus={onCloseAutoFocus}
+        >
+          <DismissableLayer
+            role="dialog"
+            id={context.contentId}
+            aria-describedby={context.descriptionId}
+            aria-labelledby={context.titleId}
+            data-state={getState(context.open)}
+            {...contentProps}
+            ref={composedRefs}
+            onDismiss={() => context.onOpenChange(false)}
+          />
+        </FocusScope>
+        {process.env.NODE_ENV !== 'production' && (
+          <>
+            <TitleWarning titleId={context.titleId} />
+            <DescriptionWarning contentRef={contentRef} descriptionId={context.descriptionId} />
+          </>
+        )}
+      </>
+    );
+  },
+);
+
+/* -------------------------------------------------------------------------------------------------
+ * DialogTitle
+ * -----------------------------------------------------------------------------------------------*/
+
+const TITLE_NAME = 'DialogTitle';
+
+type DialogTitleElement = React.ComponentRef<typeof Primitive.h2>;
+type PrimitiveHeading2Props = React.ComponentPropsWithoutRef<typeof Primitive.h2>;
+interface DialogTitleProps extends PrimitiveHeading2Props {}
+
+const DialogTitle = React.forwardRef<DialogTitleElement, DialogTitleProps>(
+  (props: ScopedProps<DialogTitleProps>, forwardedRef) => {
+    const { __scopeDialog, ...titleProps } = props;
+    const context = useDialogContext(TITLE_NAME, __scopeDialog);
+    return <Primitive.h2 id={context.titleId} {...titleProps} ref={forwardedRef} />;
+  },
+);
+
+DialogTitle.displayName = TITLE_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * DialogDescription
+ * -----------------------------------------------------------------------------------------------*/
+
+const DESCRIPTION_NAME = 'DialogDescription';
+
+type DialogDescriptionElement = React.ComponentRef<typeof Primitive.p>;
+type PrimitiveParagraphProps = React.ComponentPropsWithoutRef<typeof Primitive.p>;
+interface DialogDescriptionProps extends PrimitiveParagraphProps {}
+
+const DialogDescription = React.forwardRef<DialogDescriptionElement, DialogDescriptionProps>(
+  (props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {
+    const { __scopeDialog, ...descriptionProps } = props;
+    const context = useDialogContext(DESCRIPTION_NAME, __scopeDialog);
+    return <Primitive.p id={context.descriptionId} {...descriptionProps} ref={forwardedRef} />;
+  },
+);
+
+DialogDescription.displayName = DESCRIPTION_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * DialogClose
+ * -----------------------------------------------------------------------------------------------*/
+
+const CLOSE_NAME = 'DialogClose';
+
+type DialogCloseElement = React.ComponentRef<typeof Primitive.button>;
+interface DialogCloseProps extends PrimitiveButtonProps {}
+
+const DialogClose = React.forwardRef<DialogCloseElement, DialogCloseProps>(
+  (props: ScopedProps<DialogCloseProps>, forwardedRef) => {
+    const { __scopeDialog, ...closeProps } = props;
+    const context = useDialogContext(CLOSE_NAME, __scopeDialog);
+    return (
+      <Primitive.button
+        type="button"
+        {...closeProps}
+        ref={forwardedRef}
+        onClick={composeEventHandlers(props.onClick, () => context.onOpenChange(false))}
+      />
+    );
+  },
+);
+
+DialogClose.displayName = CLOSE_NAME;
+
+/* -----------------------------------------------------------------------------------------------*/
+
+function getState(open: boolean) {
+  return open ? 'open' : 'closed';
+}
+
+const TITLE_WARNING_NAME = 'DialogTitleWarning';
+
+const [WarningProvider, useWarningContext] = createContext(TITLE_WARNING_NAME, {
+  contentName: CONTENT_NAME,
+  titleName: TITLE_NAME,
+  docsSlug: 'dialog',
+});
+
+type TitleWarningProps = { titleId?: string };
+
+const TitleWarning: React.FC<TitleWarningProps> = ({ titleId }) => {
+  const titleWarningContext = useWarningContext(TITLE_WARNING_NAME);
+
+  const MESSAGE = `\`${titleWarningContext.contentName}\` requires a \`${titleWarningContext.titleName}\` for the component to be accessible for screen reader users.
+
+If you want to hide the \`${titleWarningContext.titleName}\`, you can wrap it with our VisuallyHidden component.
+
+For more information, see https://radix-ui.com/primitives/docs/components/${titleWarningContext.docsSlug}`;
+
+  React.useEffect(() => {
+    if (titleId) {
+      const hasTitle = document.getElementById(titleId);
+      if (!hasTitle) console.error(MESSAGE);
+    }
+  }, [MESSAGE, titleId]);
+
+  return null;
+};
+
+const DESCRIPTION_WARNING_NAME = 'DialogDescriptionWarning';
+
+type DescriptionWarningProps = {
+  contentRef: React.RefObject<DialogContentElement | null>;
+  descriptionId?: string;
+};
+
+const DescriptionWarning: React.FC<DescriptionWarningProps> = ({ contentRef, descriptionId }) => {
+  const descriptionWarningContext = useWarningContext(DESCRIPTION_WARNING_NAME);
+  const MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext.contentName}}.`;
+
+  React.useEffect(() => {
+    const describedById = contentRef.current?.getAttribute('aria-describedby');
+    // if we have an id and the user hasn't set aria-describedby={undefined}
+    if (descriptionId && describedById) {
+      const hasDescription = document.getElementById(descriptionId);
+      if (!hasDescription) console.warn(MESSAGE);
+    }
+  }, [MESSAGE, contentRef, descriptionId]);
+
+  return null;
+};
+
+const Root = Dialog;
+const Trigger = DialogTrigger;
+const Portal = DialogPortal;
+const Overlay = DialogOverlay;
+const Content = DialogContent;
+const Title = DialogTitle;
+const Description = DialogDescription;
+const Close = DialogClose;
+
+export {
+  createDialogScope,
+  //
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogOverlay,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+  //
+  Root,
+  Trigger,
+  Portal,
+  Overlay,
+  Content,
+  Title,
+  Description,
+  Close,
+  //
+  WarningProvider,
+};
+export type {
+  DialogProps,
+  DialogTriggerProps,
+  DialogPortalProps,
+  DialogOverlayProps,
+  DialogContentProps,
+  DialogTitleProps,
+  DialogDescriptionProps,
+  DialogCloseProps,
+};

--- a/shadcn-ui/dialog/dialog.md
+++ b/shadcn-ui/dialog/dialog.md
@@ -1,0 +1,126 @@
+# Dialog 컴포넌트 분석
+
+## 1. 이 컴포넌트의 역할
+이 컴포넌트는 사용자에게 **Dialog UI**를 제공하기 위한 컴포넌트다.
+
+열림 / 닫힘 상태 관리, 접근성 처리 같은 **“행동”** 은 직접 구현하지 않고,  
+Radix UI의 **Dialog Primitive**를 기반으로 UI 레이어를 얹는 역할을 한다.
+
+## 2. 구현에서 눈에 띄는 점
+Button 컴포넌트 분석 때와 마찬가지로,  
+Dialog 역시 **“행동”** 과 **“표현”** 의 책임이 분리된 구조라는 점이 가장 먼저 눈에 띄었다.
+
+### ① shadcn은 Radix를 ‘확장’하지 않고 ‘래핑’만 한다
+
+Dialog 컴포넌트의 대부분은 아래와 같은 형태를 띤다.
+
+```
+function Dialog(props) {
+  return <DialogPrimitive.Root {...props} />
+}
+```
+
+**이 구조에서 알 수 있는 점**
+
+- shadcn은 Dialog의 open / close 로직을 직접 구현하지 않는다
+- 포커스 관리, aria 속성, 키보드 접근성과 같은 **"행동"** 은 전부 Radix에 위임
+- shadcn의 역할은 Radix 컴포넌트를 감싸는 UI 레이어 제공
+
+Button 분석에서 봤던 것처럼,  
+shadcn은 “행동"과 "표현"을 모두 책임지는 라이브러리가 아니라  
+이미 검증된 **"행동"을 담당하는 외부 컴포넌트 위에 UI 레이어를 얹는 라이브러리**라는 점이 다시 한 번 드러난다.
+
+### ② data-slot → 컴포넌트 식별용 메타 정보
+Dialog 관련 컴포넌트 전반에는 `data-slot` 속성이 일관되게 붙어 있다.  
+
+```
+data-slot="dialog-content"
+data-slot="dialog-close"
+```
+
+**`data-slot`의 역할**
+- 실제 동작에는 아무 영향이 없음
+- 스타일, 테스트, 디버깅 시 컴포넌트 식별을 위한 메타 정보
+- shadcn 전반에서 공통적으로 사용하는 패턴
+
+Button 컴포넌트 분석에서 봤던 `data-slot="button"` 패턴이 Dialog에서도 그대로 반복되고 있다는 점이 인상적이었고,  
+shadcn은 이 컴포넌트가 무엇인지 DOM 레벨에서도 명확하게 드러내는 방식을 택하고 있다.  
+
+### ③ 상태 기반 스타일링은 Radix + Tailwind 조합
+**DialogOverlay**, **DialogContent**의 `className`을 보면 아래와 같은 패턴이 눈에 띈다.  
+
+```
+"data-open:animate-in data-closed:fade-out-0"
+```
+
+**설명**
+- **open / closed** 상태는 Radix가 `data-state`로 내려줌
+- shadcn은 이 상태를 **JS에서 분기 처리하지 않음**
+- 상태에 따른 표현은 전부 CSS(Tailwind)에 위임
+
+이 조합을 통해 상태 관리는 Radix가 맡고,  
+시각적 표현은 Shadcn(Tailwind)가 맡는 **명확한 책임 분리**를 다시 한 번 보여준다.
+
+### ④ asChild 패턴 → Button 재사용
+Dialog의 닫기 버튼 구현에서 특히 인상 깊었던 부분이다.
+
+```
+// DialogPrimitive.Close는 <button>이다.
+<DialogPrimitive.Close asChild>
+  <Button>Close</Button>
+</DialogPrimitive.Close>
+```
+이 코드를 풀어서 보면 다음과 같다.  
+```
+// asChild가 없는 경우
+<DialogPrimitive.Close>
+  <span>닫기</span>
+</DialogPrimitive.Close>
+
+// 실제 렌더링 결과 (DOM)
+<button type="button" aria-label="Close">
+  <span>닫기</span>
+</button>
+```
+```
+// asChild가 있는 경우
+<DialogPrimitive.Close asChild>
+  <button className="my-style">진짜 닫기 버튼</button>
+</DialogPrimitive.Close>
+
+// 실제 렌더링 결과 (DOM)
+// 부모인 Close(button)는 사라지고, 자식인 button에 "닫기 기능"만 합쳐진다.
+<button class="my-style" type="button" aria-label="Close">
+  진짜 닫기 버튼
+</button>
+```
+**asChild의 역할**
+- Radix 컴포넌트가 자식 요소를 직접 렌더링 주체로 사용하게 함
+- 이벤트 핸들러, aria 속성, role 같은 "행동"은 그대로 전달
+- 실제 DOM 요소는 자식 컴포넌트(Button)가 됨
+
+**설명**
+DialogClose가 가진 **“닫기”** 라는 행동은 그대로 유지하되,  
+UI는 Shadcn의 UI 컴포넌트(Button)를 사용하는 것이다.  
+
+이 패턴 덕분에 shadcn은 Radix의 기능을 그대로 활용하면서도  
+**본인들의 UI 컴포넌트를 일관되게 사용할 수 있다.**
+
+이렇게 기능은 유지하고, 요소만 바꾸고 싶은 상황에서 `asChild`는 굉장히 효과적인 패턴이라는 점이 인상깊었다.
+
+## 3. 왜 이렇게 설계했을까?
+Dialog처럼 복잡한 컴포넌트는 접근성, 포커스 트랩, 키보드 인터랙션까지 직접 구현하기 쉽지 않다.
+
+그래서 shadcn은 Button 컴포넌트와 마찬가지로  
+행동과 접근성은 Radix에 위임하고,  
+UI와 사용성은 shadcn이 통제하는 명확한 책임 분리 설계를 선택했을 것이다.
+
+## 4. 내가 만약 직접 만들었다면?
+아마 처음에는 하나의 Dialog 컴포넌트 안에 상태 관리, 이벤트 처리, 스타일 분기를 전부 넣었을 것이다.  
+
+그렇게 되면 여러 로직이 한 파일에 섞이면서 컴포넌트가 빠르게 복잡해졌을 가능성이 크다.
+
+## 5. 이 코드에서 배운 점
+- Button, Dialog 두 개의 컴포넌트를 분석하며 shadcn은 기능을 직접 구현하는 UI 라이브러리가 아니다.
+- 상태 분기를 JS가 아닌 CSS로 밀어내는 설계는 코드 복잡도를 크게 낮춘다.
+- `asChild` 패턴은 기능은 유지하면서 효과적으로 UI를 교체할 수 있다.


### PR DESCRIPTION
## 📝 작업 요약
- 분석한 컴포넌트: shadcn의 Dialog 컴포넌트
- 분석 기록 위치: /shadcn-ui/dialog

## 🚀 핵심 배운 점
Shadcn의 Dialog는 Button과 마찬가지로 자체적으로 기능을 구현하는 컴포넌트가 아니라,  
**Radix UI의 Dialog가 제공하는 행동을 그대로 사용하고**
**Shadcn은 UI 레이어만 담당하는 구조**로 설계되어 있다.

내부에서 상태에 따른 표현은 JS 로직에서 분기하지 않고 **CSS로 처리하는 설계**와
`asChild`로 내부 컴포넌트의 **행동은 유지한 채 UI를 다른 컴포넌트로 교체**하는 설계가 인상 깊었다.

## 🧐 셀프 피드백
### 가장 인상 깊었던 코드
```
<DialogPrimitive.Close asChild>
  <Button>Close</Button>
</DialogPrimitive.Close>
```
**이유**
이 구조를 통해 DialogClose(button)가 가진 **"닫기"라는 행동은 유지**하면서,  
실제 렌더링 되는 요소만 Shadcn의 Button으로 교체할 수 있다.

**"행동"** 과 **"표현"** 을 분리한 채 컴포넌트를 유연하게 조합할 수 있는 패턴이며,  
Shadcn이 UI 레이어를 일관되게 통제하려는 설계 철학이 잘 드러나는 부분이라고 느꼈기 때문에 가장 인상 깊었다.

### 이해하기 어려웠던 부분
```
Radix UI의 Dialog 컴포넌트 내부 구현
```

base-ui의 `Button`과 마찬가지로 내부에서 자체 커스텀 훅을 많이 사용하고 있고,  
코드 분량 또한 많아 전체 흐름을 따라가기가 쉽지 않았다.  

### 내 프로젝트에 적용한다면?
**react-optimistic-chat**에서 **ChatList**는 **ChatMessage** 외에도  
사용자 커스텀 메시지를 렌더링할 수 있도록 `messageRenderer`라는 props를 받도록 설계해 두었다.

이 구조가 내부 컴포넌트를 교체한다는 점에서 asChild 패턴과 유사하다고 느꼈고,  
더 일반화된 형태로 도입할 수 있을지 고민해보았다.  

다만 현재 단계에서는  
무조건적인 분리보다는 **복잡도 대비 얻는 이점이 충분한지**를 먼저 판단하는 것이 중요하다고 생각해  
당장 적용하기 보다는 패턴으로만 인지해 두기로 했다.  

## 🔗 관련 이슈
- Close #3 